### PR TITLE
Update `README` to 2017

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 before_script:
-  - psql -c 'create database rdrc2016_test;' -U postgres
+  - psql -c 'create database rdrc2017_test;' -U postgres
 language: ruby
 cache: bundler
 sudo: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# RedDotRubyConf 2016 Website
+# RedDotRubyConf 2017 Website
 
-[![Build Status](https://travis-ci.org/reddotrubyconf/rdrc2016.svg?branch=master)](https://travis-ci.org/reddotrubyconf/rdrc2016)
+[![Build Status](https://travis-ci.org/reddotrubyconf/rdrc2017-website.svg?branch=master)](https://travis-ci.org/reddotrubyconf/rdrc2017-website)
 
 [www.reddotrubyconf.com](http://www.reddotrubyconf.com)
 
@@ -8,13 +8,13 @@
 To contribute, [fork the repo](https://help.github.com/articles/fork-a-repo/), then clone it from your fork:
 
 ```
-$> git clone git@github.com:<your GitHub name>/rdrc2016.git
+$> git clone git@github.com:<your GitHub name>/rdrc2017-website.git
 ```
 
 Bundle and run the Rails server:
 
 ```
-$> cd rdrc2016
+$> cd rdrc2017-website
 $> bundle install
 ...
 $> bundle exec rake db:create db:migrate db:test:prepare

--- a/config/database.yml
+++ b/config/database.yml
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: rdrc2016_test
+  database: rdrc2017_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
This change updates the `README` to reflect that this is the RDRC'17 website, and changes the build badge to point to the correct Travis build.

I refrained from renaming the local databases or application namespace. (I did update the Travis database name though, to avoid weirdness, since the 2016 repo is still watched.)