### PR TITLE
[Fix #6] Add dark background contrast for white navbar text

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -5,6 +5,8 @@
 @media (min-width: $screen-sm-min) {
   .navbar {
     display: block;
+    background: rgba(135, 0, 0, 0.9);
+    border: none;
 
     transition: all 0.5s ease-in-out;
 
@@ -15,8 +17,8 @@
     }
 
     a:hover {
-      color: #333333;
-      background-color: white !important;
+      color: darkred;
+      background: rgba(255, 255, 255, 1.0) !important;
     }
   }
 
@@ -90,7 +92,7 @@
 
 #speakers {
   .anchor {
-    display:block;
+    display: block;
     position: relative;
     top: -65px;
   }


### PR DESCRIPTION
This PR adds a `darkred` 90% opacity background to the navbar which provides better contrast for the `white` text.

<img width="1357" alt="screen shot 2017-02-18 at 11 00 29 am" src="https://cloud.githubusercontent.com/assets/9073504/23089774/d5b90b2c-f5c9-11e6-950d-ea9dda222869.png">